### PR TITLE
fix: flatpak LaLa  cannot access steam folder

### DIFF
--- a/dist/com.aironheart.lala.yml
+++ b/dist/com.aironheart.lala.yml
@@ -12,6 +12,7 @@ finish-args:
   - --device=dri
   - --share=network
   - --filesystem=home
+  - --filesystem=~/.var/app/com.valvesoftware.Steam/
   - --talk-name=org.freedesktop.Flatpak
 modules:
   - name: LaLa


### PR DESCRIPTION
Fix flatpak version LaLa cannot access steam folder.
Related issue: https://github.com/wyyadd/LaLa/issues/9